### PR TITLE
Fix test_modeldownload.py

### DIFF
--- a/tests/test_modeldownload.py
+++ b/tests/test_modeldownload.py
@@ -18,8 +18,12 @@ def test_download_huggingface_model(tmp_path_factory, model="full_cat"):
     folder = tmp_path_factory.mktemp("temp")
     dlclibrary.download_huggingface_model(model, str(folder))
 
-    assert os.path.exists(folder / "pose_cfg.yaml")
-    assert any(f.startswith("snapshot-") for f in os.listdir(folder))
+    try:  # These are not created for .pt models
+        assert os.path.exists(folder / "pose_cfg.yaml")
+        assert any(f.startswith("snapshot-") for f in os.listdir(folder))
+    except AssertionError:
+        assert any(f.endswith(".pth") for f in os.listdir(folder))
+
     # Verify that the Hugging Face folder was removed
     assert not any(f.startswith("models--") for f in os.listdir(folder))
 
@@ -35,7 +39,6 @@ def test_parse_superanimal_models():
     assert "superanimal_topviewmouse" in dict_
 
 
-#@pytest.mark.skip # Not skipping as rarely run!
 @pytest.mark.parametrize("model", MODELOPTIONS)
 def test_download_all_models(tmp_path_factory, model):
     print("Downloading ...", model)


### PR DESCRIPTION
After download, the tests looked at the existence of a yaml config and a snapshot-. file, which did not exist with the two newly added models, hence the failures. This PR addresses this bug.